### PR TITLE
added ctrl-X option to close current channel window

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -11,6 +11,7 @@ void fatal(char*);
 /* net.c */
 void con_lost(int);
 void channel_sw(int);
+void channel_remove();
 void init_chans(void);
 void send_msg(char*, int);
 void recv_msg(char*, int, int);

--- a/src/input.c
+++ b/src/input.c
@@ -68,6 +68,10 @@ input(char *inp, int count)
 			del_char(1);
 		else if (c == 0x0A) /* LF */
 			ready_send();
+		else if (c == 0x18) { /* ctrl-X */
+			channel_remove();
+			draw_full();
+		}
 	} else if (count > 0 && *inp++ == 0x1B) { /* escape sequence */
 		if (esccmp("[A", inp)) /* arrow up */
 			channel_sw(0); /* FIXME: testing channel switching */

--- a/src/net.c
+++ b/src/net.c
@@ -115,6 +115,18 @@ channel_sw(int next)
 }
 
 void
+channel_remove(void)
+{
+	channel *tmp = ccur;
+	(tmp->prev)->next = ccur->next;
+	(tmp->next)->prev = ccur->prev;
+	ccur = ccur->prev;
+
+	if (tmp != ccur)
+		free(tmp);
+}
+
+void
 con_server(char *hostname, int port)
 {
 	struct hostent *host;


### PR DESCRIPTION
Hey @robbinsr,

This pull request adds an input **ctrl-X** which closes the current channel window.

**remove_channel(void)** edits the doubly-linked list to remove the current channel, then sets the current channel to the its _prev_ channel. If curr is the only channel, this will have no effect. Conversely, if curr is not the current channel, the _removed_ channel will be freed.

So, **ctrl-X** calls remove_channel(), then draw_full() to re-render the client.
