### PR TITLE
/RAW changed to /CMD_IRC, NICK Crash fix.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,6 +6,7 @@
 #define NICKSIZE 256
 #define CHANSIZE 256
 #define MAX_INPUT 256
+#define MAX_CMD 256
 #define RECONNECT_DELTA 15
 
 /* Compile time checks */

--- a/src/common.h
+++ b/src/common.h
@@ -39,15 +39,16 @@
 #define CMODE_MAX 18
 
 /* User modes */
-#define UMODE_STR "aiwroOs"
+#define UMODE_STR "aiwrRoOs"
 #define UMODE_a (1 << 0) /* away */
 #define UMODE_i (1 << 1) /* invisible */
 #define UMODE_w (1 << 2) /* receiving wallops */
 #define UMODE_r (1 << 3) /* restricted user connection */
-#define UMODE_o (1 << 4) /* operator */
-#define UMODE_O (1 << 5) /* local operator */
-#define UMODE_s (1 << 6) /* receiving server notices */
-#define UMODE_MAX 7
+#define UMODE_R (1 << 4) /* registered nicknames only*/
+#define UMODE_o (1 << 5) /* operator */
+#define UMODE_O (1 << 6) /* local operator */
+#define UMODE_s (1 << 7) /* receiving server notices */
+#define UMODE_MAX 8
 
 /* Irrecoverable error */
 #define fatal(mesg) \

--- a/src/mesg.c
+++ b/src/mesg.c
@@ -765,6 +765,9 @@ recv_mode(char *err, parsed_mesg *p, server *s)
 				case 'r':
 					modebit = UMODE_r;
 					break;
+				case 'R':
+					modebit = UMODE_R;
+					break;
 				case 'o':
 					modebit = UMODE_o;
 					break;


### PR DESCRIPTION
diff 1:

>Instead of using /RAW IRC_CMD, Now it's /IRC_CMD.
if the typed commands exists in the irc_commands array, we will call send_raw.

diff 2:
> when i typed /NICK, rirc (on startup) crashes.
