### PR TITLE
Fix compilation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ STDS := -std=c11 -D_POSIX_C_SOURCE=200809L
 
 CC := cc
 PP := cc -E
-CFLAGS   := $(CC_EXT) $(STDS) $(TLS_INCL) -I. -DVERSION=\"$(VERSION)\" -Wall -Wextra -pedantic
+CFLAGS   := $(CC_EXT) $(STDS) $(TLS_INCL) -I. -DVERSION=\"$(VERSION)\" -D_DARWIN_C_SOURCE -Wall -Wextra -pedantic
 CFLAGS_R := $(CFLAGS) -O2 -flto -DNDEBUG
 CFLAGS_D := $(CFLAGS) -O0 -g
 LDFLAGS  := $(LD_EXT) -lpthread


### PR DESCRIPTION
On macOS `SIGWINCH` is only defined if `_DARWIN_C_SOURCE` is set. Hopefully this doesn't break Linux builds.
```c
#if  (!defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE))
#define SIGWINCH 28     /* window size changes */
#define SIGINFO 29      /* information request */
#endif
```