### PR TITLE
Update man page commands (/priv -> /privmsg)

### DIFF
--- a/rirc.1
+++ b/rirc.1
@@ -112,7 +112,7 @@ IRC commands:
   /me;<message>
   /nick;[nick]
   /part;[target [targets...]] [part message]
-  /priv;<target> <message>
+  /privmsg;<target> <message>
   /quit;[quit message]
   /raw;<message>
 .TE


### PR DESCRIPTION
The man page states there's a `/priv` command, but the command is actually `/privmsg`.