### PR TITLE
Fix pthreads for linux glibc build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ RIRC_CFLAGS += -D_POSIX_C_SOURCE=200809L
 RIRC_CFLAGS += -D_DARWIN_C_SOURCE
 
 LDFLAGS ?= -flto
-LDFLAGS += -lpthread
+LDFLAGS += -pthread
 
 SRC       := $(shell find $(PATH_SRC) -name '*.c' | sort)
 SRC_GPERF := $(patsubst %, %.out, $(shell find $(PATH_SRC) -name '*.gperf'))


### PR DESCRIPTION
The master branch of rirc fails to link for me on Debian testing. The last step of the build looks like this:

```
cc -flto -lpthread rirc
/usr/bin/ld: /tmp/rirc.MYoBsH.ltrans1.ltrans.o: in function `io_thread.lto_priv.0':
<artificial>:(.text+0x8d19): undefined reference to `pthread_sigmask'
/usr/bin/ld: /tmp/rirc.MYoBsH.ltrans0.ltrans.o: in function `io_cx':
<artificial>:(.text+0x7a04): undefined reference to `pthread_kill'
/usr/bin/ld: <artificial>:(.text+0x7a74): undefined reference to `pthread_sigmask'
/usr/bin/ld: <artificial>:(.text+0x7a95): undefined reference to `pthread_create'
/usr/bin/ld: <artificial>:(.text+0x7aae): undefined reference to `pthread_sigmask'
/usr/bin/ld: /tmp/rirc.MYoBsH.ltrans0.ltrans.o: in function `io_dx':
<artificial>:(.text+0x7bcd): undefined reference to `pthread_detach'
/usr/bin/ld: <artificial>:(.text+0x7be2): undefined reference to `pthread_kill'
collect2: error: ld returned 1 exit status
make: *** [Makefile:39: rirc] Error 1
```

The issue is that on Linux with glibc, to build a multi-threaded program you should use `-pthread` instead of `-lpthread`. The difference is that `-pthread` implies `-D_REENTRANT` (in addition to `-lpthread`), and various glibc features are guarded with ifdef macros based on whether or not `_REENTRANT` is defined. Therefore if you only link with `-lpthread` some glibc features may not be defined correctly. Clang implements the same behavior for this flag.