### PR TITLE
Remove SonarCloud cache and threads setup as it is now by default

### DIFF
--- a/scripts/sa_sonarscan_run.sh
+++ b/scripts/sa_sonarscan_run.sh
@@ -42,8 +42,6 @@ sonar.links.ci       = https://builds.sr.ht/~rcr/rirc/
 
 # C, Sources
 sonar.cfamily.build-wrapper-output = $BUILD_WRAPPER_OUT
-sonar.cfamily.cache.enabled        = false
-sonar.cfamily.threads              = $(nproc)
 sonar.sources                      = src
 
 # Output


### PR DESCRIPTION
No need to configure the cache and threads anymore, 
SonarCloud now has automatic analysis caching. See:
https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.