### PR TITLE
Makefile: Add _XOPEN_SOURCE macro for *BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS  = -flto
 CPPFLAGS = -I. -D_POSIX_C_SOURCE=200809L -DVERSION=$(VERSION)
 
 ifneq ($(filter %BSD,$(shell uname -s)),)
-	CPPFLAGS += -D_BSD_SOURCE -D__BSD_VISIBLE
+	CPPFLAGS += -D_BSD_SOURCE -D__BSD_VISIBLE -D_XOPEN_SOURCE=600
 endif
 
 ifneq ($(filter Darwin,$(shell uname -s)),)


### PR DESCRIPTION
When building rirc on FreeBSD, I noticed some compiler warnings about a function called gettimeofday() is implicitly defined there. Even adding "sys/time.h" header, it seems like the function gettimeofday() is only visible, if __XSI_VISIBLE is defined (or simply _XOPEN_SOURCE).

GNU systems, usually avoid such macros, with _GNU_SOURCE or _DEFAULT_SOURCE macro. *BSD needs this (at least _XOPEN_SOURCE >= 600) to use this function.

Prototype definition: https://github.com/freebsd/freebsd-src/blob/13037eaabede7fb7fbc25f4e84b549c73f9acb3c/sys/sys/time.h#L631