### PR TITLE
Fix make install on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,14 @@ rirc: config.h $(OBJ) $(MBEDTLS)
 	$(CC) $(LDFLAGS) -pthread $(OBJ) $(MBEDTLS) -o $@
 
 install: rirc
-	@sed -i "s/VERSION/$(VERSION)/g" rirc.1
+	@sed -i.bak "s/VERSION/$(VERSION)/g" rirc.1
 	mkdir -p $(PATH_BIN)
 	mkdir -p $(PATH_MAN)
 	cp -f rirc   $(PATH_BIN)
 	cp -f rirc.1 $(PATH_MAN)
 	chmod 755 $(PATH_BIN)/rirc
 	chmod 644 $(PATH_MAN)/rirc.1
+	rm -f rirc.1.bak
 
 uninstall:
 	rm -f $(PATH_BIN)/rirc


### PR DESCRIPTION
macOS uses the BSD version of sed that unlike the GNU version, requires the backup suffix to be supplied when using `-i` or `-I`.

There are a couple of ways to accommodate for this, but this seemed like the cleanest cross-platform way to me. GNU sed requires there to be no space between the option and parameter, BSD sed doesn't mind either way. 